### PR TITLE
feat: add daily spin limit and error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ async-trait = "0.1"
 thiserror = "1.0"
 dotenv = "0.15"
 tracing = "0.1"
-tracing-subscriber = "0.3" 
+tracing-subscriber = "0.3"
+chrono = { version = "0.4", features = ["serde"] } 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Create a `.env` file in the root directory:
 ```
 NOTION_API_KEY=your_notion_api_key
 NOTION_DATABASE_ID=your_notion_database_id
+DAILY_SPIN_LIMIT=3 # Optional: defaults to 1
 ```
 
 

--- a/src/domain/repository.rs
+++ b/src/domain/repository.rs
@@ -11,6 +11,8 @@ pub trait NotionRepository {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Daily spin limit reached")]
+    SpinLimitReached,
     #[error("Notion API error: {0}")]
     NotionApi(String),
     #[error("Serialization error: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,12 @@ async fn main() {
         .expect("NOTION_DATABASE_ID must be set");
     let api_token = env::var("NOTION_API_TOKEN")
         .expect("NOTION_API_TOKEN must be set");
+    let daily_spin_limit = env::var("DAILY_SPIN_LIMIT")
+        .unwrap_or_else(|_| "1".to_string())
+        .parse::<i32>()
+        .unwrap_or(1);
 
-    let notion_client = NotionClient::new(database_id, api_token);
+    let notion_client = NotionClient::new(database_id, api_token, daily_spin_limit);
     let notion_service = NotionService::new(notion_client);
     
     let app = api::routes::create_router(notion_service);


### PR DESCRIPTION
### Problems

This PR introduces a daily spin limit feature to the application. Here's a brief and clear description of the changes:

1. Added a configurable daily spin limit, defaulting to 1.
2. Implemented spin limit checking in the Notion client.
3. Updated error handling to return a 429 (Too Many Requests) status when the limit is reached.
4. Added a new environment variable DAILY_SPIN_LIMIT for easy configuration.
5. Updated dependencies to include chrono for date handling.

These changes allow the application to restrict the number of spins per phone number per day, improving control over user interactions.

### Solutions

This solution adds a daily spin limit feature to the Notion-based spin result tracking system. Here are the key changes:

1. Added chrono dependency for date/time handling.
2. Introduced a DAILY_SPIN_LIMIT environment variable.
3. Modified NotionClient to include daily_spin_limit.
4. Implemented has_reached_spin_limit method to check if a user has reached their daily limit.
5. Updated create_entry method to check spin limit before creating a new entry.
6. Added SpinLimitReached error type.
7. Modified create_spin_result handler to return 429 Too Many Requests when spin limit is reached.
8. Updated main.rs to parse and pass the daily spin limit to NotionClient.

These changes allow the system to enforce a configurable daily spin limit per user, returning an appropriate error when the limit is exceeded.

### Changes

Here are the main changes in present tense, specific but concise:

1. Adds chrono dependency with serde feature to Cargo.toml
2. Introduces DAILY_SPIN_LIMIT environment variable in README.md
3. Updates error handling in create_spin_result handler to return 429 for spin limit errors
4. Adds SpinLimitReached error variant to repository Error enum
5. Extends NotionClient to include daily_spin_limit field
6. Implements has_reached_spin_limit method in NotionClient
7. Modifies create_entry method to check spin limit before creating new entries
8. Updates main.rs to parse DAILY_SPIN_LIMIT from environment and pass it to NotionClient